### PR TITLE
fixed meta-tag waring issue

### DIFF
--- a/app/views/layouts/application.html.haml
+++ b/app/views/layouts/application.html.haml
@@ -2,7 +2,7 @@
 %html
   %head
     %title RecipeGuru
-    %meta{ name: "viewport", content: "width=divice-width, initial-scale=1" }
+    %meta{ name: "viewport", content: "width=device-width, initial-scale=1" }
     = stylesheet_link_tag    "application", media: "all"
     = javascript_include_tag "application"
     = csrf_meta_tags


### PR DESCRIPTION
Meta tag was generating  *\* The value "divice-width" for key "width" is invalid, and has been ignored. *\* warning because of invalid value of content attribute. Corrected that value.
